### PR TITLE
refactor: 重构书签同步为基于内容哈希的方案

### DIFF
--- a/packages/app/src/background/autoSync.ts
+++ b/packages/app/src/background/autoSync.ts
@@ -2,19 +2,92 @@
  * 自动同步服务
  * 监听书签变化，自动上传到云端
  * 定时检查云端更新，自动合并到本地
+ *
+ * 注意：MV3 Service Worker 是事件驱动的
+ * - 书签事件会自动唤醒 SW
+ * - Alarm 事件会自动唤醒 SW
+ * - 状态使用 storage.session 持久化，避免 SW 休眠后丢失
  */
 import browser from "webextension-polyfill";
-import { smartPush, smartPull, SyncConfig } from "../services/syncService";
+import { getCloudInfo, smartPull, smartPush, SyncConfig } from "../services/syncService";
 
-// 防抖定时器
-// 状态标志
-let isRestoring = false; // 是否正在执行恢复操作（防止死循环）
+// ============================================
+// 常量定义
+// ============================================
 const LOCK_HOLDER_AUTO = "auto_sync"; // 自动同步的锁持有者标识
+const ALARM_NAME = "scheduledSync"; // 定时同步闹钟名称
+const DEBOUNCE_ALARM = "autoSyncDebounce"; // 防抖闹钟名称
+const RESET_RESTORING_ALARM = "resetRestoring"; // 重置恢复状态闹钟名称
+const RESTORING_KEY = "isRestoring"; // storage.session 中的恢复状态键
+const RESTORING_TIMEOUT_MS = 10000; // 恢复状态超时时间（10秒）
+const DEBOUNCE_DELAY_MS = 1000; // 防抖延迟时间（1秒）
+const RESET_RESTORING_DELAY_MS = 3000; // 重置恢复状态延迟（3秒）
 
-const ALARM_NAME = "scheduledSync";
+// ============================================
+// 状态管理（使用 storage.session 持久化）
+// ============================================
 
-// 防抖定时器 Alarm 名称
-const DEBOUNCE_ALARM = "autoSyncDebounce";
+/**
+ * 检查是否正在执行恢复操作
+ * 使用 storage.session 确保 Service Worker 重启后状态不丢失
+ */
+async function getIsRestoring(): Promise<boolean> {
+  try {
+    // Firefox 不支持 storage.session，此时返回 false
+    if (!browser.storage.session) {
+      return false;
+    }
+
+    const result = await browser.storage.session.get(RESTORING_KEY);
+    const state = result[RESTORING_KEY] as
+      | { value: boolean; timestamp: number }
+      | undefined;
+
+    if (!state) return false;
+
+    // 检查超时（防止异常情况下状态一直锁定）
+    const now = Date.now();
+    if (now - state.timestamp > RESTORING_TIMEOUT_MS) {
+      console.warn(
+        `[AutoSync] Restoring state timeout (${now - state.timestamp}ms), auto clearing`,
+      );
+      await setIsRestoring(false);
+      return false;
+    }
+
+    return state.value;
+  } catch (error) {
+    console.error("[AutoSync] Failed to get restoring state:", error);
+    return false;
+  }
+}
+
+/**
+ * 设置恢复状态
+ */
+async function setIsRestoring(value: boolean): Promise<void> {
+  try {
+    if (!browser.storage.session) {
+      console.warn("[AutoSync] storage.session not supported");
+      return;
+    }
+
+    if (value) {
+      await browser.storage.session.set({
+        [RESTORING_KEY]: {
+          value: true,
+          timestamp: Date.now(),
+        },
+      });
+      console.log("[AutoSync] Restoring state activated");
+    } else {
+      await browser.storage.session.remove(RESTORING_KEY);
+      console.log("[AutoSync] Restoring state cleared");
+    }
+  } catch (error) {
+    console.error("[AutoSync] Failed to set restoring state:", error);
+  }
+}
 
 /**
  * 获取 WebDAV 配置
@@ -56,188 +129,391 @@ async function getWebDAVConfig(): Promise<{
   };
 }
 
+// ============================================
+// 同步执行函数
+// ============================================
+
 /**
- * 执行上传同步 (Push) - 使用统一 syncService
+ * 执行上传同步 (Push)
+ * 自动上传本地书签变化到云端
  */
-async function executeUpload() {
-  if (isRestoring) return;
+async function executeUpload(): Promise<void> {
+  try {
+    // 检查是否正在恢复（避免循环触发）
+    if (await getIsRestoring()) {
+      console.log("[AutoSync] Skipped upload: restoring in progress");
+      return;
+    }
 
-  const { config, autoSyncEnabled } = await getWebDAVConfig();
-  if (!config || !autoSyncEnabled) return;
+    // 检查网络状态
+    if (!navigator.onLine) {
+      console.log("[AutoSync] Skipped upload: offline");
+      return;
+    }
 
-  await smartPush(config, LOCK_HOLDER_AUTO, false);
+    // 获取配置
+    const { config, autoSyncEnabled } = await getWebDAVConfig();
+    if (!config) {
+      console.log("[AutoSync] Skipped upload: no config");
+      return;
+    }
+
+    if (!autoSyncEnabled) {
+      console.log("[AutoSync] Skipped upload: auto sync disabled");
+      return;
+    }
+
+    console.log("[AutoSync] Starting upload...");
+    const result = await smartPush(config, LOCK_HOLDER_AUTO);
+
+    if (result.success) {
+      console.log(`[AutoSync] Upload ${result.action}: ${result.message}`);
+    } else {
+      console.warn(`[AutoSync] Upload failed: ${result.message}`);
+    }
+  } catch (error) {
+    console.error("[AutoSync] Upload error:", error);
+  }
 }
 
 /**
- * 执行拉取同步 (Pull) - 使用统一 syncService
- * 如果云端比本地新，则自动恢复
+ * 执行拉取同步 (Pull)
+ * 检查云端更新并自动同步到本地
  */
-async function executeAutoPull() {
-  if (isRestoring) return;
-
-  const { config } = await getWebDAVConfig();
-  if (!config) return;
-
-  // 检查云端是否有更新
-  const result = await browser.storage.local.get([
-    "lastSyncTime",
-    "lastSyncUrl",
-  ]);
-  const lastSyncTime =
-    result.lastSyncUrl === config.url
-      ? (result.lastSyncTime as number) || 0
-      : 0;
-
-  // 获取云端时间戳
+async function executeAutoPull(): Promise<void> {
   try {
-    const { getCloudInfo } = await import("../services/syncService");
+    console.log("[AutoSync] Checking for cloud updates...");
+
+    // 检查是否正在恢复
+    if (await getIsRestoring()) {
+      console.log("[AutoSync] Skipped pull: restoring in progress");
+      return;
+    }
+
+    // 检查网络状态
+    if (!navigator.onLine) {
+      console.log("[AutoSync] Skipped pull: offline");
+      return;
+    }
+
+    // 获取配置
+    const { config } = await getWebDAVConfig();
+    if (!config) {
+      console.log("[AutoSync] Skipped pull: no config");
+      return;
+    }
+
+    // 获取本地同步记录
+    const storageResult = await browser.storage.local.get([
+      "lastSyncTime",
+      "lastSyncUrl",
+    ]);
+
+    const lastSyncTime =
+      storageResult.lastSyncUrl === config.url
+        ? (storageResult.lastSyncTime as number) || 0
+        : 0;
+
+    // 获取云端信息
     const cloudInfo = await getCloudInfo(config);
-    if (!cloudInfo.exists) return;
+
+    if (!cloudInfo.exists) {
+      console.log("[AutoSync] No cloud backup found");
+      return;
+    }
 
     const cloudTime = cloudInfo.timestamp || 0;
-    if (cloudTime <= lastSyncTime) return;
 
-    // 标记正在恢复，阻止 onBookmarkChanged 触发上传
-    isRestoring = true;
+    // 比对时间戳
+    if (cloudTime <= lastSyncTime) {
+      console.log(
+        `[AutoSync] No updates (cloud: ${new Date(cloudTime).toISOString()}, local: ${new Date(lastSyncTime).toISOString()})`,
+      );
+      return;
+    }
+
+    console.log(
+      `[AutoSync] Cloud update detected (${cloudInfo.totalCount} bookmarks from ${cloudInfo.browser || "unknown"})`,
+    );
+
+    // 标记正在恢复，阻止书签变化事件触发上传
+    await setIsRestoring(true);
 
     try {
-      await smartPull(config, LOCK_HOLDER_AUTO, "overwrite");
+      const pullResult = await smartPull(config, LOCK_HOLDER_AUTO, "overwrite");
+
+      if (pullResult.success) {
+        console.log(`[AutoSync] Pull ${pullResult.action}: ${pullResult.message}`);
+      } else {
+        console.warn(`[AutoSync] Pull failed: ${pullResult.message}`);
+      }
     } finally {
-      // 延迟重置恢复标志，等待所有事件处理完成
-      setTimeout(() => {
-        isRestoring = false;
-      }, 2000);
+      // 使用 Alarm 延迟重置恢复标志（避免 setTimeout 在 SW 休眠后丢失）
+      // 延迟时间足够长，确保书签恢复操作完全完成
+      await browser.alarms.create(RESET_RESTORING_ALARM, {
+        when: Date.now() + RESET_RESTORING_DELAY_MS,
+      });
     }
-  } catch {
-    // 忽略错误
+  } catch (error) {
+    console.error("[AutoSync] Pull error:", error);
+    // 发生错误时立即重置状态
+    await setIsRestoring(false);
   }
 }
 
-// 防抖定时器 Alarm 名称
+// ============================================
+// 防抖同步机制
+// ============================================
 
 /**
- * 触发防抖同步 (使用 Alarm 以防止 Service Worker 休眠导致 Timer 丢失)
+ * 触发防抖同步
+ * 使用 Alarm API 以防止 Service Worker 休眠导致 Timer 丢失
+ * 当书签发生变化时调用，会延迟执行上传避免频繁同步
  */
-async function triggerDebouncedSync() {
-  if (isRestoring) return;
+async function triggerDebouncedSync(): Promise<void> {
+  try {
+    // 如果正在恢复，不触发上传
+    if (await getIsRestoring()) {
+      console.log("[AutoSync] Skipped debounce: restoring in progress");
+      return;
+    }
 
-  // 清除旧的防抖闹钟（如果存在）
-  await browser.alarms.clear(DEBOUNCE_ALARM);
+    // 清除旧的防抖闹钟（如果存在）
+    const cleared = await browser.alarms.clear(DEBOUNCE_ALARM);
+    if (cleared) {
+      console.log("[AutoSync] Debounce alarm reset");
+    }
 
-  // 创建新的防抖闹钟 (3秒后触发)
-  // 注意：Chrome 扩展对于 periodInMinutes 有限制，但对于 when (一次性) 通常允许短时间
-  await browser.alarms.create(DEBOUNCE_ALARM, {
-    when: Date.now() + 3000,
-  });
+    // 创建新的防抖闹钟
+    // 注意：Chrome 扩展的 Alarm API 对于一次性闹钟（when）支持任意时间
+    await browser.alarms.create(DEBOUNCE_ALARM, {
+      when: Date.now() + DEBOUNCE_DELAY_MS,
+    });
+
+    console.log(`[AutoSync] Upload scheduled in ${DEBOUNCE_DELAY_MS}ms`);
+  } catch (error) {
+    console.error("[AutoSync] Failed to trigger debounced sync:", error);
+  }
 }
 
 /**
- * 处理防抖闹钟
+ * 处理防抖闹钟触发
  */
-async function handleDebounceAlarm(alarm: browser.Alarms.Alarm) {
+async function handleDebounceAlarm(alarm: browser.Alarms.Alarm): Promise<void> {
   if (alarm.name !== DEBOUNCE_ALARM) return;
 
-  // 再次检查开关
+  console.log("[AutoSync] Debounce alarm triggered");
+
+  // 再次检查自动同步开关
   const { autoSyncEnabled } = await getWebDAVConfig();
-  if (autoSyncEnabled) {
-    await executeUpload();
+
+  if (!autoSyncEnabled) {
+    console.log("[AutoSync] Auto sync disabled, skipping upload");
+    return;
   }
+
+  await executeUpload();
 }
 
+// ============================================
+// 书签变化监听（顶级作用域注册）
+// ============================================
+
 /**
- * 启动自动同步监听 (现仅需确保逻辑就绪，监听器已在顶级注册)
+ * 书签事件处理器
+ * 当书签发生任何变化时触发防抖上传
  */
-export function startAutoSync() {
+const onBookmarkEvent = (): void => {
+  triggerDebouncedSync();
+};
+
+// 注册所有书签变化事件
+// 必须在顶级作用域注册，确保 Service Worker 能被事件唤醒
+browser.bookmarks.onCreated.addListener(onBookmarkEvent);
+browser.bookmarks.onRemoved.addListener(onBookmarkEvent);
+browser.bookmarks.onChanged.addListener(onBookmarkEvent);
+browser.bookmarks.onMoved.addListener(onBookmarkEvent);
+
+console.log("[AutoSync] Bookmark listeners registered");
+
+// ============================================
+// 导出的控制函数
+// ============================================
+
+/**
+ * 启动自动同步服务
+ * 在扩展安装/启动时调用
+ */
+export function startAutoSync(): void {
+  console.log("[AutoSync] Auto sync service started");
+  // 检查云端更新
   checkCloudOnStartup();
 }
 
 /**
- * 停止自动同步监听 (实际上 Service Worker 无法真正移除顶级监听，只能通过标记位控制，但此处保留接口)
+ * 停止自动同步服务
+ * 注意：MV3 Service Worker 无法真正移除顶级监听器
+ * 实际控制通过配置中的开关实现
  */
-export function stopAutoSync() {
-  // 在 MV3 中，通常通过内部状态判断是否执行
+export function stopAutoSync(): void {
+  console.log("[AutoSync] Auto sync service stopped (listeners remain active)");
+  // 在 MV3 中，监听器会一直存在，通过配置开关控制是否执行
 }
-
-// ==========================================
-// 顶级注册监听器 (确保 Service Worker 始终被唤醒)
-// ==========================================
-
-// 1. 书签事件监听
-const onBookmarkParams = () => triggerDebouncedSync();
-browser.bookmarks.onCreated.addListener(onBookmarkParams);
-browser.bookmarks.onRemoved.addListener(onBookmarkParams);
-browser.bookmarks.onChanged.addListener(onBookmarkParams);
-browser.bookmarks.onMoved.addListener(onBookmarkParams);
-
-// 2. 防抖闹钟监听 (复用 handleAlarm 逻辑或单独注册)
-browser.alarms.onAlarm.addListener((alarm) => {
-  if (alarm.name === DEBOUNCE_ALARM) {
-    handleDebounceAlarm(alarm);
-  }
-  // 注意：scheduledSync 的 handleAlarm 在下面注册，或者我们需要合并监听器？
-  // 由于 browser.alarms.onAlarm 可以有多个监听器，这里分开写没问题。
-});
 
 /**
  * 扩展启动时检查云端更新
+ * 如果云端有新版本，自动同步到本地
  */
-export async function checkCloudOnStartup() {
+export async function checkCloudOnStartup(): Promise<void> {
+  console.log("[AutoSync] Checking cloud on startup...");
   await executeAutoPull();
 }
 
+// ============================================
+// 定时同步管理
+// ============================================
+
 /**
  * 启动定时同步
+ * 根据配置创建周期性的云端检查任务
  */
-export async function startScheduledSync() {
-  const { scheduledSyncEnabled, scheduledSyncInterval } =
-    await getWebDAVConfig();
+export async function startScheduledSync(): Promise<void> {
+  try {
+    const { scheduledSyncEnabled, scheduledSyncInterval } =
+      await getWebDAVConfig();
 
-  if (!scheduledSyncEnabled) {
-    await browser.alarms.clear(ALARM_NAME);
-    return;
+    if (!scheduledSyncEnabled) {
+      const cleared = await browser.alarms.clear(ALARM_NAME);
+      if (cleared) {
+        console.log("[AutoSync] Scheduled sync disabled and alarm cleared");
+      }
+      return;
+    }
+
+    // 检查是否已存在同名 Alarm
+    const existingAlarm = await browser.alarms.get(ALARM_NAME);
+
+    if (existingAlarm) {
+      // 如果已存在且周期一致，则不重置（防止无限推迟首次触发）
+      if (existingAlarm.periodInMinutes === scheduledSyncInterval) {
+        console.log(
+          `[AutoSync] Scheduled sync already running (${scheduledSyncInterval}min)`,
+        );
+        return;
+      }
+      // 如果周期变了，清除旧的并创建新的
+      await browser.alarms.clear(ALARM_NAME);
+      console.log("[AutoSync] Scheduled sync interval changed, recreating alarm");
+    }
+
+    // 创建周期性定时器
+    await browser.alarms.create(ALARM_NAME, {
+      periodInMinutes: scheduledSyncInterval,
+      when: Date.now() + scheduledSyncInterval * 60 * 1000, // 首次触发时间
+    });
+
+    console.log(
+      `[AutoSync] Scheduled sync started (every ${scheduledSyncInterval}min)`,
+    );
+  } catch (error) {
+    console.error("[AutoSync] Failed to start scheduled sync:", error);
   }
-
-  // 创建定时器
-  await browser.alarms.create(ALARM_NAME, {
-    periodInMinutes: scheduledSyncInterval,
-  });
 }
 
 /**
  * 停止定时同步
  */
-export async function stopScheduledSync() {
-  await browser.alarms.clear(ALARM_NAME);
+export async function stopScheduledSync(): Promise<void> {
+  try {
+    const cleared = await browser.alarms.clear(ALARM_NAME);
+    if (cleared) {
+      console.log("[AutoSync] Scheduled sync stopped");
+    }
+  } catch (error) {
+    console.error("[AutoSync] Failed to stop scheduled sync:", error);
+  }
 }
 
 /**
- * 处理定时器触发
+ * 处理定时同步闹钟触发
  */
-async function handleAlarm(alarm: browser.Alarms.Alarm) {
+async function handleScheduledAlarm(alarm: browser.Alarms.Alarm): Promise<void> {
   if (alarm.name !== ALARM_NAME) return;
+
+  console.log("[AutoSync] Scheduled sync triggered");
 
   // 再次检查开关状态，确保即使用户关闭了开关但 Alarm 还没清除时也不会运行
   const { scheduledSyncEnabled } = await getWebDAVConfig();
-  if (!scheduledSyncEnabled) return;
+  if (!scheduledSyncEnabled) {
+    console.log("[AutoSync] Scheduled sync disabled, skipping");
+    await browser.alarms.clear(ALARM_NAME);
+    return;
+  }
 
   await executeAutoPull();
 }
 
 /**
  * 更新定时同步配置
+ * 用于设置页面保存配置时调用
  */
-export async function updateScheduledSync() {
-  const { scheduledSyncEnabled, scheduledSyncInterval } =
-    await getWebDAVConfig();
+export async function updateScheduledSync(): Promise<void> {
+  try {
+    const { scheduledSyncEnabled, scheduledSyncInterval } =
+      await getWebDAVConfig();
 
-  if (scheduledSyncEnabled) {
-    await browser.alarms.create(ALARM_NAME, {
-      periodInMinutes: scheduledSyncInterval,
-    });
-  } else {
-    await browser.alarms.clear(ALARM_NAME);
+    if (scheduledSyncEnabled) {
+      // 清除旧的并创建新的
+      await browser.alarms.clear(ALARM_NAME);
+      await browser.alarms.create(ALARM_NAME, {
+        periodInMinutes: scheduledSyncInterval,
+        when: Date.now() + scheduledSyncInterval * 60 * 1000,
+      });
+      console.log(
+        `[AutoSync] Scheduled sync updated (every ${scheduledSyncInterval}min)`,
+      );
+    } else {
+      await browser.alarms.clear(ALARM_NAME);
+      console.log("[AutoSync] Scheduled sync disabled");
+    }
+  } catch (error) {
+    console.error("[AutoSync] Failed to update scheduled sync:", error);
   }
 }
 
-// 注册监听器 (必须在顶级作用域注册，以确保 Service Worker 唤醒时能立即响应)
-browser.alarms.onAlarm.addListener(handleAlarm);
+// ============================================
+// 全局事件监听器（顶级作用域注册）
+// ============================================
+
+/**
+ * Alarm 事件统一处理器
+ * 必须在顶级作用域注册，确保 Service Worker 唤醒时能立即响应
+ */
+browser.alarms.onAlarm.addListener(async (alarm) => {
+  try {
+    console.log(`[AutoSync] Alarm triggered: ${alarm.name}`);
+
+    switch (alarm.name) {
+      case DEBOUNCE_ALARM:
+        // 防抖上传
+        await handleDebounceAlarm(alarm);
+        break;
+
+      case ALARM_NAME:
+        // 定时同步
+        await handleScheduledAlarm(alarm);
+        break;
+
+      case RESET_RESTORING_ALARM:
+        // 重置恢复状态
+        console.log("[AutoSync] Resetting restoring state");
+        await setIsRestoring(false);
+        break;
+
+      default:
+        console.warn(`[AutoSync] Unknown alarm: ${alarm.name}`);
+    }
+  } catch (error) {
+    console.error(`[AutoSync] Alarm handler error (${alarm.name}):`, error);
+  }
+});

--- a/packages/app/src/lib/bookmarksApi.ts
+++ b/packages/app/src/lib/bookmarksApi.ts
@@ -40,7 +40,7 @@ export const BookmarksAPI = {
    */
   update(
     id: string,
-    changes: { title?: string; url?: string },
+    changes: browser.Bookmarks.UpdateChangesType,
   ): Promise<browser.Bookmarks.BookmarkTreeNode> {
     return browser.bookmarks.update(id, changes);
   },
@@ -50,5 +50,15 @@ export const BookmarksAPI = {
    */
   remove(id: string): Promise<void> {
     return browser.bookmarks.remove(id);
+  },
+
+  /**
+   * 移动书签/文件夹
+   */
+  move(
+    id: string,
+    destination: browser.Bookmarks.MoveDestinationType,
+  ): Promise<browser.Bookmarks.BookmarkTreeNode> {
+    return browser.bookmarks.move(id, destination);
   },
 };

--- a/packages/app/src/lib/utils.ts
+++ b/packages/app/src/lib/utils.ts
@@ -4,3 +4,18 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * 生成内容哈希（用于书签同步）
+ * @param url 书签 URL
+ * @param title 书签标题
+ * @returns SHA-256 哈希值（64 个十六进制字符）
+ */
+export async function generateHash(url: string, title: string): Promise<string> {
+  const content = `${url}|${title}`;
+  const encoder = new TextEncoder();
+  const data = encoder.encode(content);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+}

--- a/packages/app/src/services/bookmarkService.ts
+++ b/packages/app/src/services/bookmarkService.ts
@@ -1,6 +1,7 @@
-import { CloudBackup, BookmarkMetadata, BookmarkNode } from "../types";
-import { getBrowserInfo } from "../lib/browser";
 import { BookmarksAPI } from "../lib/bookmarksApi";
+import { getBrowserInfo } from "../lib/browser";
+import { generateHash } from "../lib/utils";
+import { BookmarkMetadata, BookmarkNode, CloudBackup } from "../types";
 
 // ============================================================================
 // 跨浏览器系统文件夹映射
@@ -32,20 +33,13 @@ const FIREFOX_SYSTEM_IDS = [
 
 /**
  * 判断节点是否为系统根文件夹（不应参与内容比对）
- * - Chrome/Edge 根节点 (id="0", 标题为空)
- * - Firefox 根节点 (id="root________")
- * - Chrome/Edge 系统文件夹 (有 folderType 属性)
- * - Firefox 系统文件夹 (特殊 ID)
  */
 function isSystemRootFolder(node: BookmarkNode): boolean {
   if (node.url) return false;
-  // Chrome/Edge 根节点
+  if (!node.id) return false; // 没有 id 的节点不是系统文件夹
   if (node.id === "0" && !node.title) return true;
-  // Firefox 根节点
   if (node.id === "root________") return true;
-  // Chrome/Edge: 有 folderType 属性
   if (node.folderType) return true;
-  // Firefox: 使用特殊 ID
   return FIREFOX_SYSTEM_IDS.includes(node.id);
 }
 
@@ -56,14 +50,11 @@ function findMatchingSystemFolder(
   backupNode: BookmarkNode,
   localFolders: BookmarkNode[],
 ): BookmarkNode | null {
-  // 1. Chrome/Edge 备份 -> 本地匹配
   if (backupNode.folderType) {
-    // 优先匹配相同 folderType
     const match = localFolders.find(
       (l) => l.folderType === backupNode.folderType,
     );
     if (match) return match;
-    // 跨浏览器: Chrome/Edge -> Firefox
     const firefoxId = FOLDER_TYPE_TO_FIREFOX_ID[backupNode.folderType];
     if (firefoxId) {
       const firefoxMatch = localFolders.find((l) => l.id === firefoxId);
@@ -71,22 +62,551 @@ function findMatchingSystemFolder(
     }
   }
 
-  // 2. Firefox 备份 -> 本地匹配
-  const mappedType = FIREFOX_ID_TO_FOLDER_TYPE[backupNode.id];
-  if (mappedType) {
-    // Firefox -> Chrome/Edge
-    const match = localFolders.find((l) => l.folderType === mappedType);
-    if (match) return match;
-    // Firefox -> Firefox
-    const sameIdMatch = localFolders.find((l) => l.id === backupNode.id);
-    if (sameIdMatch) return sameIdMatch;
+  if (backupNode.id) {
+    const mappedType = FIREFOX_ID_TO_FOLDER_TYPE[backupNode.id];
+    if (mappedType) {
+      const match = localFolders.find((l) => l.folderType === mappedType);
+      if (match) return match;
+      const sameIdMatch = localFolders.find((l) => l.id === backupNode.id);
+      if (sameIdMatch) return sameIdMatch;
+    }
   }
 
-  // 3. 标题匹配（普通文件夹）
   const titleMatch = localFolders.find((l) => l.title === backupNode.title);
   if (titleMatch) return titleMatch;
 
   return null;
+}
+
+// ============================================================================
+// 全局索引类型定义
+// ============================================================================
+
+/** 节点位置信息（通用） */
+interface NodeLocation {
+  id?: string; // 云端数据可能没有 id
+  hash?: string; // 内容哈希（用于跨浏览器匹配）
+  parentId: string;
+  index: number;
+  title: string;
+  url?: string; // 书签有 URL
+  path?: string; // 文件夹有路径
+  isFolder: boolean;
+}
+
+/** 书签位置信息 */
+interface BookmarkLocation {
+  id?: string; // 云端数据可能没有 id
+  hash?: string; // 内容哈希
+  parentId: string;
+  index: number;
+  title: string;
+  url: string;
+}
+
+/** 文件夹位置信息 */
+interface FolderLocation {
+  id?: string; // 云端数据可能没有 id
+  hash?: string; // 内容哈希（文件夹通常不需要 hash，但保留字段一致性）
+  parentId: string;
+  index: number;
+  title: string;
+  path: string;
+}
+
+/** 全局索引 */
+interface GlobalIndex {
+  /** Hash -> 节点信息（主要匹配方式） */
+  hashToNode: Map<string, NodeLocation>;
+  /** URL -> 书签列表（兜底匹配，可能有多个相同 URL） */
+  urlToBookmarks: Map<string, BookmarkLocation[]>;
+  /** 路径 -> 文件夹信息（兜底匹配） */
+  pathToFolder: Map<string, FolderLocation>;
+  /** ID -> 路径 */
+  idToPath: Map<string, string>;
+}
+
+// ============================================================================
+// 全局索引构建
+// ============================================================================
+
+/**
+ * 标准化 URL
+ */
+function normalizeUrl(url: string | undefined): string {
+  if (!url) return "";
+  return url
+    .trim()
+    .replace(/\/+$/, "")
+    .replace(/^(https?):\/\//i, (_, proto) => proto.toLowerCase() + "://");
+}
+
+/**
+ * 通过 Hash 查找节点（优先从本地子节点查找，否则从全局索引构建）
+ */
+function findNodeByHash(
+  hash: string,
+  localIndex: GlobalIndex,
+  localChildren: BookmarkNode[],
+  processedLocalIds: Set<string>,
+): BookmarkNode | undefined {
+  const hashMatch = localIndex.hashToNode.get(hash);
+  if (!hashMatch || !hashMatch.id || processedLocalIds.has(hashMatch.id)) {
+    return undefined;
+  }
+
+  // 先尝试从本地子节点获取完整信息
+  const localNode = localChildren.find((l) => l.id === hashMatch.id);
+  if (localNode) {
+    return localNode;
+  }
+
+  // 节点不在当前文件夹，从全局索引构建基本信息
+  return {
+    id: hashMatch.id,
+    title: hashMatch.title,
+    url: hashMatch.url,
+    parentId: hashMatch.parentId,
+    index: hashMatch.index,
+    children: hashMatch.isFolder ? [] : undefined,
+  };
+}
+
+/**
+ * 构建全局索引（本地树：动态计算 hash）
+ */
+async function buildGlobalIndex(tree: BookmarkNode[]): Promise<GlobalIndex> {
+  const hashToNode = new Map<string, NodeLocation>();
+  const urlToBookmarks = new Map<string, BookmarkLocation[]>();
+  const pathToFolder = new Map<string, FolderLocation>();
+  const idToPath = new Map<string, string>();
+
+  async function traverse(node: BookmarkNode, parentPath: string) {
+    const currentPath = parentPath ? `${parentPath}/${node.title}` : node.title;
+
+    if (node.url) {
+      // 书签：计算 hash
+      const normalizedUrl = normalizeUrl(node.url);
+      const hash = await generateHash(normalizedUrl, node.title);
+      
+      const location: BookmarkLocation = {
+        id: node.id,
+        hash,
+        parentId: node.parentId || "",
+        index: node.index ?? 0,
+        title: node.title,
+        url: normalizedUrl,
+      };
+      
+      // Hash 索引（主要匹配方式）
+      hashToNode.set(hash, {
+        id: node.id,
+        hash,
+        parentId: node.parentId || "",
+        index: node.index ?? 0,
+        title: node.title,
+        url: normalizedUrl,
+        isFolder: false,
+      });
+      
+      // URL 索引（兜底匹配）
+      const existing = urlToBookmarks.get(normalizedUrl) || [];
+      existing.push(location);
+      urlToBookmarks.set(normalizedUrl, existing);
+    } else if (node.children) {
+      // 文件夹
+      if (!isSystemRootFolder(node)) {
+        const location: FolderLocation = {
+          id: node.id,
+          parentId: node.parentId || "",
+          index: node.index ?? 0,
+          title: node.title,
+          path: currentPath,
+        };
+        
+        // 路径索引（文件夹不需要 hash，按路径匹配）
+        pathToFolder.set(currentPath, location);
+        if (node.id) {
+          idToPath.set(node.id, currentPath);
+        }
+      }
+
+      for (const child of node.children) {
+        await traverse(child, isSystemRootFolder(node) ? "" : currentPath);
+      }
+    }
+  }
+
+  for (const node of tree) {
+    await traverse(node, "");
+  }
+
+  return { hashToNode, urlToBookmarks, pathToFolder, idToPath };
+}
+
+// ============================================================================
+// 三阶段同步实现
+// ============================================================================
+
+/**
+ * 执行智能同步（三阶段）
+ * @param localParentId 本地系统文件夹 ID
+ * @param cloudNodes 云端该文件夹下的节点
+ * @param localIndex 本地全局索引
+ * @param localParentPath 本地父路径
+ */
+async function smartSync(
+  localParentId: string,
+  cloudNodes: BookmarkNode[],
+  localIndex: GlobalIndex,
+  localParentPath: string,
+): Promise<void> {
+  console.log(
+    `[BookmarkService] Syncing folder "${localParentPath}" (${cloudNodes.length} cloud nodes)`,
+  );
+
+  // 获取当前本地文件夹的子节点
+  const localChildren = (await BookmarksAPI.getChildren(
+    localParentId,
+  )) as BookmarkNode[];
+
+  console.log(
+    `[BookmarkService] Local folder has ${localChildren.length} children`,
+  );
+
+  // 已处理的本地 ID（防止重复处理）
+  const processedLocalIds = new Set<string>();
+  // 已使用的 URL（用于检测重复）
+  const usedUrls = new Set<string>();
+
+  // 统计信息
+  let stats = {
+    bookmarksCreated: 0,
+    bookmarksMoved: 0,
+    bookmarksUpdated: 0,
+    foldersCreated: 0,
+    foldersMoved: 0,
+    itemsDeleted: 0,
+  };
+
+  // Phase 1 & 2: 处理云端节点（创建/移动/更新）
+  for (let i = 0; i < cloudNodes.length; i++) {
+    const cloudNode = cloudNodes[i];
+
+    if (cloudNode.url) {
+      // === 处理书签 ===
+      const normalizedUrl = normalizeUrl(cloudNode.url);
+      let matchedLocal: BookmarkNode | undefined;
+
+      // 1. 优先通过 Hash 匹配（最可靠）
+      if (cloudNode.hash) {
+        matchedLocal = findNodeByHash(
+          cloudNode.hash,
+          localIndex,
+          localChildren,
+          processedLocalIds,
+        );
+      }
+
+      // 2. Hash 匹配失败，通过 URL 兜底匹配（兼容旧数据或重复URL）
+      if (!matchedLocal) {
+        // 先在当前文件夹找
+        matchedLocal = localChildren.find(
+          (local) =>
+            local.id &&
+            normalizeUrl(local.url) === normalizedUrl &&
+            !processedLocalIds.has(local.id),
+        );
+
+        // 如果当前文件夹没有，从全局索引找
+        if (!matchedLocal && !usedUrls.has(normalizedUrl)) {
+          const globalMatches = localIndex.urlToBookmarks.get(normalizedUrl);
+          if (globalMatches && globalMatches.length > 0) {
+            for (const gm of globalMatches) {
+              if (gm.id && !processedLocalIds.has(gm.id)) {
+                matchedLocal = {
+                  id: gm.id,
+                  title: gm.title,
+                  url: gm.url,
+                  parentId: gm.parentId,
+                  index: gm.index,
+                };
+                break;
+              }
+            }
+          }
+        }
+      }
+
+      if (matchedLocal && matchedLocal.id) {
+        processedLocalIds.add(matchedLocal.id);
+        usedUrls.add(normalizedUrl);
+
+        // 检查是否需要更新
+        const updates: { title?: string; url?: string } = {};
+
+        // 更新标题
+        if ((matchedLocal.title?.trim() || "") !== (cloudNode.title?.trim() || "")) {
+          updates.title = cloudNode.title;
+        }
+
+        // 更新 URL（新功能！）
+        if (normalizeUrl(matchedLocal.url) !== normalizedUrl) {
+          updates.url = cloudNode.url;
+        }
+
+        if (Object.keys(updates).length > 0) {
+          try {
+            await BookmarksAPI.update(matchedLocal.id, updates);
+            stats.bookmarksUpdated++;
+          } catch (error) {
+            console.warn(
+              `[BookmarkService] Failed to update bookmark ${matchedLocal.id}:`,
+              error,
+            );
+          }
+        }
+
+        // 调整位置（如果不在当前文件夹或索引不对）
+        if (
+          matchedLocal.parentId !== localParentId ||
+          matchedLocal.index !== i
+        ) {
+          try {
+            await BookmarksAPI.move(matchedLocal.id, {
+              parentId: localParentId,
+              index: i,
+            });
+            stats.bookmarksMoved++;
+          } catch (error) {
+            console.warn(
+              `[BookmarkService] Failed to move bookmark ${matchedLocal.id}:`,
+              error,
+            );
+          }
+        }
+      } else {
+        // 创建新书签
+        usedUrls.add(normalizedUrl);
+        try {
+          const newBookmark = await BookmarksAPI.create({
+            parentId: localParentId,
+            title: cloudNode.title,
+            url: cloudNode.url,
+            index: i,
+          });
+          if (newBookmark.id) {
+            processedLocalIds.add(newBookmark.id); // 记录新创建的 ID，防止 Phase 3 误删
+            stats.bookmarksCreated++;
+          }
+        } catch (error) {
+          console.warn(
+            `[BookmarkService] Failed to create bookmark "${cloudNode.title}":`,
+            error,
+          );
+        }
+      }
+    } else if (cloudNode.children) {
+      // === 处理文件夹 ===
+      const cloudFolderPath = localParentPath
+        ? `${localParentPath}/${cloudNode.title}`
+        : cloudNode.title;
+      let matchedFolder: BookmarkNode | undefined;
+
+      // 1. 先在当前文件夹找同名文件夹（简单匹配）
+      matchedFolder = localChildren.find(
+        (local) =>
+          local.id &&
+          !local.url &&
+          (local.title?.trim() || "") === (cloudNode.title?.trim() || "") &&
+          !processedLocalIds.has(local.id),
+      );
+
+      // 2. 如果没找到，从全局索引按路径找
+      if (!matchedFolder) {
+        const globalFolder = localIndex.pathToFolder.get(cloudFolderPath);
+        if (globalFolder && globalFolder.id && !processedLocalIds.has(globalFolder.id)) {
+          matchedFolder = {
+            id: globalFolder.id,
+            title: globalFolder.title,
+            parentId: globalFolder.parentId,
+            index: globalFolder.index,
+            children: [],
+          };
+        }
+      }
+
+      if (matchedFolder && matchedFolder.id) {
+        processedLocalIds.add(matchedFolder.id);
+
+        // 更新标题（如果改名了）
+        if ((matchedFolder.title?.trim() || "") !== (cloudNode.title?.trim() || "")) {
+          try {
+            await BookmarksAPI.update(matchedFolder.id, { title: cloudNode.title });
+            stats.bookmarksUpdated++; // 复用统计字段
+          } catch (error) {
+            console.warn(
+              `[BookmarkService] Failed to update folder title ${matchedFolder.id}:`,
+              error,
+            );
+          }
+        }
+
+        // 调整位置（如果移动了）
+        if (
+          matchedFolder.parentId !== localParentId ||
+          matchedFolder.index !== i
+        ) {
+          try {
+            await BookmarksAPI.move(matchedFolder.id, {
+              parentId: localParentId,
+              index: i,
+            });
+            stats.foldersMoved++;
+          } catch (error) {
+            console.warn(
+              `[BookmarkService] Failed to move folder ${matchedFolder.id}:`,
+              error,
+            );
+          }
+        }
+
+        // 递归同步子节点
+        await smartSync(
+          matchedFolder.id,
+          cloudNode.children,
+          localIndex,
+          cloudFolderPath,
+        );
+      } else {
+        // 创建新文件夹
+        try {
+          const created = await BookmarksAPI.create({
+            parentId: localParentId,
+            title: cloudNode.title,
+            index: i,
+          });
+          if (created.id) {
+            processedLocalIds.add(created.id); // 记录新创建的 ID，防止 Phase 3 误删
+            stats.foldersCreated++;
+            
+            // 递归创建子节点
+            await createChildren(created.id, cloudNode.children);
+          }
+        } catch (error) {
+          console.warn(
+            `[BookmarkService] Failed to create folder "${cloudNode.title}":`,
+            error,
+          );
+        }
+      }
+    }
+  }
+
+  // Phase 3: 删除本地多余的节点
+  // 重新获取当前子节点（因为可能有移动/创建）
+  const finalLocalChildren = (await BookmarksAPI.getChildren(
+    localParentId,
+  )) as BookmarkNode[];
+
+  for (const localNode of finalLocalChildren) {
+    if (!localNode.id || processedLocalIds.has(localNode.id)) continue;
+
+    // 这个节点在云端不存在，删除它
+    try {
+      const removeMethod = localNode.url
+        ? BookmarksAPI.remove(localNode.id)
+        : BookmarksAPI.removeTree(localNode.id);
+      
+      await removeMethod;
+      stats.itemsDeleted++;
+    } catch (error) {
+      const nodeType = localNode.url ? "bookmark" : "folder";
+      console.warn(
+        `[BookmarkService] Failed to delete ${nodeType} ${localNode.id}:`,
+        error,
+      );
+    }
+  }
+
+  // 输出统计信息
+  if (
+    stats.bookmarksCreated +
+      stats.bookmarksMoved +
+      stats.bookmarksUpdated +
+      stats.foldersCreated +
+      stats.foldersMoved +
+      stats.itemsDeleted >
+    0
+  ) {
+    console.log(
+      `[BookmarkService] Sync stats for "${localParentPath}":`,
+      `Created: ${stats.bookmarksCreated} bookmarks, ${stats.foldersCreated} folders`,
+      `| Moved: ${stats.bookmarksMoved} bookmarks, ${stats.foldersMoved} folders`,
+      `| Updated: ${stats.bookmarksUpdated} bookmarks`,
+      `| Deleted: ${stats.itemsDeleted} items`,
+    );
+  }
+}
+
+/**
+ * 递归创建子节点
+ */
+async function createChildren(
+  parentId: string,
+  children: BookmarkNode[],
+): Promise<void> {
+  for (const node of children) {
+    try {
+      const created = await BookmarksAPI.create({
+        parentId,
+        title: node.title,
+        url: node.url,
+        index: node.index,
+      });
+
+      if (created.id && node.children && node.children.length > 0) {
+        await createChildren(created.id, node.children);
+      }
+    } catch {
+      // 忽略创建失败
+    }
+  }
+}
+
+// ============================================================================
+// 导出的 BookmarkService
+// ============================================================================
+
+/**
+ * 为单个书签节点分配 Hash（递归处理子节点）
+ * 只保留云端同步必需的字段
+ */
+async function assignHashToNode(node: BookmarkNode): Promise<BookmarkNode> {
+  const newNode: BookmarkNode = {
+    title: node.title, // 显示名称
+    url: node.url,  // 书签地址（书签必需）
+  };
+
+  // 为系统文件夹保留识别字段（用于跨浏览器匹配）
+  if (isSystemRootFolder(node)) {
+    newNode.id = node.id; // Firefox ID 或 Chrome/Edge 的特殊 ID
+    newNode.folderType = node.folderType; // Chrome/Edge 的 folderType
+  }
+
+  // 为书签计算 hash
+  if (node.url) {
+    newNode.hash = await generateHash(normalizeUrl(node.url), node.title);
+  }
+
+  // 递归处理子节点
+  if (node.children) {
+    newNode.children = await Promise.all(
+      node.children.map((child) => assignHashToNode(child))
+    );
+  }
+
+  return newNode;
 }
 
 export const BookmarkService = {
@@ -95,145 +615,51 @@ export const BookmarkService = {
     return (await BookmarksAPI.getTree()) as BookmarkNode[];
   },
 
-  /**
-   * Wrap bookmarks with metadata
-   */
+  /** 创建云端备份 */
   async createCloudBackup(): Promise<CloudBackup> {
     const tree = await this.getTree();
-    const count = this.countBookmarks(tree);
+    
+    // 为所有节点分配 Hash（动态计算）
+    const treeWithHash = await this.assignHashes(tree);
+    
+    const count = this.countBookmarks(treeWithHash);
     const browserInfo = getBrowserInfo();
 
     const metadata: BookmarkMetadata = {
       timestamp: Date.now(),
       totalCount: count,
-      clientVersion: "1.0.0",
+      clientVersion: "2.0.0-hash", // Hash 版本
       browser: browserInfo.name,
       browserVersion: browserInfo.version,
       stats: {
-        totalFolders: this.countFolders(tree),
+        totalFolders: this.countFolders(treeWithHash),
       },
     };
 
-    return {
-      metadata,
-      data: tree,
-    };
+    return { metadata, data: treeWithHash };
   },
 
   /**
-   * 标准化 URL 用于比较
-   * 去除末尾斜杠、统一小写协议、去除空格
+   * 为书签树的所有节点分配 Hash
    */
-  normalizeUrl(url: string | undefined): string {
-    if (!url) return "";
-    return url
-      .trim()
-      .replace(/\/+$/, "") // 去除末尾斜杠
-      .replace(/^(https?):\/\//i, (_, proto) => proto.toLowerCase() + "://"); // 统一协议小写
+  async assignHashes(nodes: BookmarkNode[]): Promise<BookmarkNode[]> {
+    return Promise.all(nodes.map((node) => assignHashToNode(node)));
   },
 
-  /**
-   * 增量同步：只更新差异部分
-   * @param parentId 父文件夹 ID
-   * @param cloudNodes 云端节点列表
-   * @param localNodes 本地节点列表
-   */
-  async syncNodes(
-    parentId: string,
-    cloudNodes: BookmarkNode[],
-    localNodes: BookmarkNode[],
-  ): Promise<void> {
-    // 用于跟踪已匹配的本地节点，防止重复匹配
-    const matchedLocalIds = new Set<string>();
-
-    // 第一遍：处理云端节点（新增/更新）
-    for (const cloudNode of cloudNodes) {
-      let matchedLocal: BookmarkNode | undefined;
-
-      if (cloudNode.url) {
-        // 书签：按 URL 匹配（标准化后比较）
-        const cloudUrl = this.normalizeUrl(cloudNode.url);
-        matchedLocal = localNodes.find(
-          (local) =>
-            this.normalizeUrl(local.url) === cloudUrl &&
-            !matchedLocalIds.has(local.id),
-        );
-      } else {
-        // 文件夹：按 title 匹配（忽略前后空格）
-        const cloudTitle = cloudNode.title?.trim() || "";
-        matchedLocal = localNodes.find(
-          (local) =>
-            !local.url &&
-            (local.title?.trim() || "") === cloudTitle &&
-            !matchedLocalIds.has(local.id),
-        );
-      }
-
-      if (matchedLocal) {
-        // 已存在，标记为已匹配
-        matchedLocalIds.add(matchedLocal.id);
-
-        if (cloudNode.url) {
-          // 书签：检查标题是否需要更新
-          if (
-            (matchedLocal.title?.trim() || "") !==
-            (cloudNode.title?.trim() || "")
-          ) {
-            await BookmarksAPI.update(matchedLocal.id, {
-              title: cloudNode.title,
-            });
-          }
-        } else {
-          // 文件夹：递归同步子节点（即使云端是空文件夹也需要同步，以清理本地多余内容）
-          const localChildren = await BookmarksAPI.getChildren(matchedLocal.id);
-          await this.syncNodes(
-            matchedLocal.id,
-            cloudNode.children || [],
-            localChildren as BookmarkNode[],
-          );
-        }
-      } else {
-        // 本地不存在，创建新节点
-        const created = await BookmarksAPI.create({
-          parentId,
-          title: cloudNode.title,
-          url: cloudNode.url,
-        });
-
-        // 如果是文件夹，递归创建子节点
-        if (cloudNode.children && cloudNode.children.length > 0) {
-          await this.createChildren(created.id, cloudNode.children);
-        }
-      }
-    }
-
-    // 第二遍：删除本地多余的节点（云端没有的）
-    for (const localNode of localNodes) {
-      if (!matchedLocalIds.has(localNode.id)) {
-        // 本地存在但云端没有，删除
-        try {
-          if (localNode.url) {
-            // 书签：直接删除
-            await BookmarksAPI.remove(localNode.id);
-          } else {
-            // 文件夹：递归删除
-            await BookmarksAPI.removeTree(localNode.id);
-          }
-        } catch {
-          // 忽略删除失败（可能是特殊文件夹）
-        }
-      }
-    }
-  },
+  /** 标准化 URL */
+  normalizeUrl,
 
   /**
-   * Restore bookmarks from CloudBackup (or legacy array) - 增量同步版本
+   * 从备份恢复（使用全局索引 + 三阶段同步）
    */
   async restoreFromBackup(backup: CloudBackup | BookmarkNode[]): Promise<void> {
+    const startTime = Date.now();
+    console.log("[BookmarkService] Starting restore from backup...");
+
+    // 验证备份数据
     let tree: BookmarkNode[];
 
     if (Array.isArray(backup)) {
-      // Legacy format support
       tree = backup;
     } else if (backup && backup.data) {
       tree = backup.data;
@@ -246,68 +672,86 @@ export const BookmarkService = {
     }
 
     const root = tree[0];
-
     if (!root || !root.children) {
       throw new Error("备份数据格式无效：缺少根节点或子节点");
     }
 
-    // 获取当前浏览器的根文件夹
-    const localTree = await this.getTree();
-    const localRoot = localTree[0];
+    const backupCount = this.countBookmarks(tree);
+    console.log(`[BookmarkService] Backup contains ${backupCount} bookmarks`);
 
+    // 获取本地书签树并构建全局索引
+    console.log("[BookmarkService] Building global index...");
+    const localTree = await this.getTree();
+    const localIndex = await buildGlobalIndex(localTree);
+    console.log(
+      `[BookmarkService] Index: ${localIndex.urlToBookmarks.size} URLs, ${localIndex.pathToFolder.size} folders`,
+    );
+
+    const localRoot = localTree[0];
     if (!localRoot || !localRoot.children) {
       throw new Error("无法获取本地书签根结构");
     }
 
     const localChildren = localRoot.children;
 
-    // 使用增量同步恢复内容
+    // 对每个系统文件夹执行智能同步
+    console.log(
+      `[BookmarkService] Syncing ${root.children.length} system folders...`,
+    );
+
     for (const backupChild of root.children) {
       const targetFolder = findMatchingSystemFolder(backupChild, localChildren);
 
-      if (targetFolder && backupChild.children) {
-        const localFolderChildren = await BookmarksAPI.getChildren(
-          targetFolder.id,
-        );
-        await this.syncNodes(
+      if (targetFolder && targetFolder.id && backupChild.children) {
+        const folderName =
+          targetFolder.title || targetFolder.folderType || "system";
+        console.log(`[BookmarkService] Syncing folder: ${folderName}`);
+        await smartSync(
           targetFolder.id,
           backupChild.children,
-          localFolderChildren as BookmarkNode[],
+          localIndex,
+          folderName,
         );
+      } else {
+        // 静默忽略跨浏览器不兼容的系统文件夹
+        // Firefox: "书签菜单" (menu________)、"移动设备书签" (mobile______)
+        // 这些文件夹在 Chrome/Edge 中可能不存在
+        const ignoredFolderIds = ["menu________", "mobile______"];
+        const shouldIgnore = backupChild.id && ignoredFolderIds.includes(backupChild.id);
+        
+        if (!shouldIgnore) {
+          console.warn(
+            `[BookmarkService] No matching system folder found for ${backupChild.title}`,
+          );
+        }
       }
-      // 如果找不到对应的文件夹，跳过这个备份文件夹（不要用 fallback，避免数据错乱）
     }
+
+    const elapsed = Date.now() - startTime;
+    console.log(`[BookmarkService] Restore completed in ${elapsed}ms`);
   },
 
+  /** 清空文件夹 */
   async emptyFolder(id: string): Promise<void> {
     const children = await BookmarksAPI.getChildren(id);
-
     for (const child of children) {
       await BookmarksAPI.removeTree(child.id);
     }
   },
 
-  async createChildren(parentId: string, children: BookmarkNode[]) {
-    for (const node of children) {
-      const created = await BookmarksAPI.create({
-        parentId: parentId,
-        title: node.title,
-        url: node.url,
-        index: node.index,
-      });
-
-      if (node.children && node.children.length > 0) {
-        await this.createChildren(created.id, node.children);
-      }
-    }
+  /** 递归创建子节点 */
+  async createChildren(
+    parentId: string,
+    children: BookmarkNode[],
+  ): Promise<void> {
+    await createChildren(parentId, children);
   },
 
+  /** 统计书签数量 */
   countBookmarks(nodes: BookmarkNode[]): number {
     let count = 0;
     for (const node of nodes) {
-      if (node.url) {
-        count++;
-      }
+      if (node.url) count++;
       if (node.children && node.children.length > 0) {
         count += this.countBookmarks(node.children);
       }
@@ -315,18 +759,19 @@ export const BookmarkService = {
     return count;
   },
 
+  /** 统计文件夹数量 */
   countFolders(nodes: BookmarkNode[]): number {
     let count = 0;
     for (const node of nodes) {
       if (!node.url && node.children) {
-        // Is folder
-        if (node.id !== "0") count++; // Skip root
+        if (node.id !== "0") count++;
         count += this.countFolders(node.children);
       }
     }
     return count;
   },
 
+  /** 合并备份（只添加不存在的） */
   async mergeFromBackup(backup: CloudBackup | BookmarkNode[]): Promise<void> {
     let tree: BookmarkNode[];
 
@@ -341,7 +786,6 @@ export const BookmarkService = {
       throw new Error("Invalid bookmark backup format");
     }
 
-    // Iterate root children (usually "1" and "2")
     for (const child of root.children) {
       if (child.id === "1" || child.id === "2") {
         await this.mergeNodes(child.id, child.children || []);
@@ -349,59 +793,73 @@ export const BookmarkService = {
     }
   },
 
-  async mergeNodes(parentId: string, nodes: BookmarkNode[]) {
+  /** 合并节点（只添加新的） */
+  async mergeNodes(parentId: string, nodes: BookmarkNode[]): Promise<void> {
     const localChildren = await BookmarksAPI.getChildren(parentId);
+    let addedCount = 0;
 
     for (const node of nodes) {
       if (node.url) {
-        // Bookmark: Check by URL
         const exists = localChildren.some((local) => local.url === node.url);
         if (!exists) {
-          await BookmarksAPI.create({
-            parentId,
-            title: node.title,
-            url: node.url,
-            index: node.index,
-          });
+          try {
+            await BookmarksAPI.create({
+              parentId,
+              title: node.title,
+              url: node.url,
+              index: node.index,
+            });
+            addedCount++;
+          } catch (error) {
+            console.warn(
+              `[BookmarkService] Failed to create bookmark during merge: ${node.title}`,
+              error,
+            );
+          }
         }
       } else {
-        // Folder: Check by Title
         const existingFolder = localChildren.find(
           (local) => !local.url && local.title === node.title,
         );
 
         if (existingFolder) {
-          // Folder exists, merge contents
           if (node.children && node.children.length > 0) {
             await this.mergeNodes(existingFolder.id, node.children);
           }
         } else {
-          // New folder, create and populate
-          const newFolder = await BookmarksAPI.create({
-            parentId,
-            title: node.title,
-            index: node.index,
-          });
+          try {
+            const newFolder = await BookmarksAPI.create({
+              parentId,
+              title: node.title,
+              index: node.index,
+            });
+            addedCount++;
 
-          if (node.children && node.children.length > 0) {
-            // Optimized: Create whole subtree without checking
-            await this.createChildren(newFolder.id, node.children);
+            if (node.children && node.children.length > 0) {
+              await createChildren(newFolder.id, node.children);
+            }
+          } catch (error) {
+            console.warn(
+              `[BookmarkService] Failed to create folder during merge: ${node.title}`,
+              error,
+            );
           }
         }
       }
     }
+
+    if (addedCount > 0) {
+      console.log(`[BookmarkService] Merged ${addedCount} new items`);
+    }
   },
 
+  /** 获取本地书签数量 */
   async getLocalCount(): Promise<number> {
     const tree = await this.getTree();
     return this.countBookmarks(tree);
   },
 
-  /**
-   * 提取书签和文件夹的内容签名列表（用于比对）
-   * - 书签: "B|URL|Title"
-   * - 文件夹: "F|Title|ChildCount"
-   */
+  /** 提取签名（用于快速比对） */
   extractSignatures(nodes: BookmarkNode[]): string[] {
     const signatures: string[] = [];
 
@@ -421,25 +879,67 @@ export const BookmarkService = {
       }
     }
 
-    return signatures.sort();
+    return signatures;
   },
 
-  /** 比对本地书签和云端书签是否一致 */
-  compareWithCloud(
-    localTree: BookmarkNode[],
-    cloudData: CloudBackup | BookmarkNode[],
-  ): boolean {
-    const cloudTree = Array.isArray(cloudData) ? cloudData : cloudData.data;
+  /** 提取签名（使用 hash，用于精确比对）*/
+  extractSignaturesWithHash(nodes: BookmarkNode[]): string[] {
+    const signatures: string[] = [];
 
-    const localSigs = this.extractSignatures(localTree);
-    const cloudSigs = this.extractSignatures(cloudTree);
+    for (const node of nodes) {
+      if (!isSystemRootFolder(node)) {
+        if (node.url && node.hash) {
+          // 书签：使用 hash 作为唯一标识
+          signatures.push(`B|${node.hash}`);
+        } else if (!node.url) {
+          // 文件夹：使用标题和子节点数量
+          signatures.push(
+            `F|${node.title.trim()}|${node.children?.length ?? 0}`,
+          );
+        }
+      }
 
-    if (localSigs.length !== cloudSigs.length) return false;
-
-    for (let i = 0; i < localSigs.length; i++) {
-      if (localSigs[i] !== cloudSigs[i]) return false;
+      if (node.children?.length) {
+        signatures.push(...this.extractSignaturesWithHash(node.children));
+      }
     }
 
+    return signatures;
+  },
+
+  /** 比对本地和云端是否一致 */
+  async compareWithCloud(
+    localTree: BookmarkNode[],
+    cloudData: CloudBackup | BookmarkNode[],
+  ): Promise<boolean> {
+    const cloudTree = Array.isArray(cloudData) ? cloudData : cloudData.data;
+
+    // 为了准确比对，先将本地树也转换为云端格式（精简字段 + 添加 hash）
+    const normalizedLocalTree = await this.assignHashes(localTree);
+
+    const localSigs = this.extractSignaturesWithHash(normalizedLocalTree);
+    const cloudSigs = this.extractSignaturesWithHash(cloudTree);
+
+    console.log(
+      `[BookmarkService] Comparing signatures: local=${localSigs.length}, cloud=${cloudSigs.length}`,
+    );
+
+    if (localSigs.length !== cloudSigs.length) {
+      console.log("[BookmarkService] Signature count differs");
+      return false;
+    }
+
+    // 找出第一个不同的签名（用于调试）
+    for (let i = 0; i < localSigs.length; i++) {
+      if (localSigs[i] !== cloudSigs[i]) {
+        console.log(
+          `[BookmarkService] Signature differs at index ${i}:\nLocal: ${localSigs[i]}\nCloud: ${cloudSigs[i]}`,
+        );
+        return false;
+      }
+    }
+
+    console.log("[BookmarkService] Signatures match");
     return true;
   },
 };

--- a/packages/app/src/services/syncService.ts
+++ b/packages/app/src/services/syncService.ts
@@ -3,12 +3,14 @@
  * 提供自动同步、手动同步、定时同步共用的核心逻辑
  */
 import browser from "webextension-polyfill";
-import { BookmarkService } from "./bookmarkService";
-import { BackupService } from "./backupService";
-import { createWebDAVClient, WebDAVClient } from "./webdav";
+import { getBrowserInfo, isSameBrowser } from "../lib/browser";
 import { CloudBackup } from "../types";
+import { BookmarkService } from "./bookmarkService";
+import { createWebDAVClient, WebDAVClient } from "./webdav";
 
-// ============ 同步锁 ============
+// ============================================
+// 同步锁机制
+// ============================================
 
 const LOCK_KEY = "sync_lock";
 const LOCK_TIMEOUT_MS = 60000; // 60 秒超时自动释放
@@ -16,36 +18,91 @@ const LOCK_TIMEOUT_MS = 60000; // 60 秒超时自动释放
 interface SyncLock {
   holder: string;
   timestamp: number;
+  lockId: string; // 用于验证锁的有效性，防止 race condition
 }
 
 /**
  * 尝试获取同步锁
+ * 使用 lockId 机制防止并发获取时的竞态条件
  */
 async function acquireSyncLock(holder: string): Promise<boolean> {
-  const result = await browser.storage.local.get(LOCK_KEY);
-  const existingLock = result[LOCK_KEY] as SyncLock | undefined;
+  try {
+    const result = await browser.storage.local.get(LOCK_KEY);
+    const existingLock = result[LOCK_KEY] as SyncLock | undefined;
 
-  if (existingLock) {
-    const now = Date.now();
-    if (now - existingLock.timestamp < LOCK_TIMEOUT_MS) {
-      return false;
+    // 检查现有锁
+    if (existingLock) {
+      const now = Date.now();
+      const lockAge = now - existingLock.timestamp;
+
+      // 锁未超时，无法获取
+      if (lockAge < LOCK_TIMEOUT_MS) {
+        console.log(
+          `[SyncService] Lock held by "${existingLock.holder}" (${Math.round(lockAge / 1000)}s ago)`,
+        );
+        return false;
+      }
+
+      // 锁已超时，可以强制获取
+      console.warn(
+        `[SyncService] Lock timeout detected (${Math.round(lockAge / 1000)}s), force acquiring`,
+      );
     }
-  }
 
-  const newLock: SyncLock = { holder, timestamp: Date.now() };
-  await browser.storage.local.set({ [LOCK_KEY]: newLock });
-  return true;
+    // 生成唯一 lockId 用于验证
+    const lockId = `${holder}_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    const newLock: SyncLock = {
+      holder,
+      timestamp: Date.now(),
+      lockId,
+    };
+
+    // 写入锁
+    await browser.storage.local.set({ [LOCK_KEY]: newLock });
+
+    // 重新读取验证（防止并发写入导致的覆盖）
+    await new Promise((resolve) => setTimeout(resolve, 50)); // 短暂延迟
+    const verifyResult = await browser.storage.local.get(LOCK_KEY);
+    const verifyLock = verifyResult[LOCK_KEY] as SyncLock | undefined;
+
+    if (verifyLock?.lockId === lockId) {
+      console.log(`[SyncService] Lock acquired by "${holder}"`);
+      return true;
+    }
+
+    // 验证失败，其他进程抢先获取了锁
+    console.warn(`[SyncService] Lock verification failed for "${holder}"`);
+    return false;
+  } catch (error) {
+    console.error("[SyncService] Failed to acquire lock:", error);
+    return false;
+  }
 }
 
 /**
  * 释放同步锁
+ * 只有锁的持有者才能释放
  */
 async function releaseSyncLock(holder: string): Promise<void> {
-  const result = await browser.storage.local.get(LOCK_KEY);
-  const existingLock = result[LOCK_KEY] as SyncLock | undefined;
+  try {
+    const result = await browser.storage.local.get(LOCK_KEY);
+    const existingLock = result[LOCK_KEY] as SyncLock | undefined;
 
-  if (existingLock && existingLock.holder === holder) {
-    await browser.storage.local.remove(LOCK_KEY);
+    if (!existingLock) {
+      console.log(`[SyncService] No lock to release for "${holder}"`);
+      return;
+    }
+
+    if (existingLock.holder === holder) {
+      await browser.storage.local.remove(LOCK_KEY);
+      console.log(`[SyncService] Lock released by "${holder}"`);
+    } else {
+      console.warn(
+        `[SyncService] Lock held by "${existingLock.holder}", cannot release by "${holder}"`,
+      );
+    }
+  } catch (error) {
+    console.error("[SyncService] Failed to release lock:", error);
   }
 }
 
@@ -81,21 +138,24 @@ function getClient(config: SyncConfig): WebDAVClient {
  * 智能上传：检查内容差异，只有真正有变化时才上传
  * @param config WebDAV 配置
  * @param lockHolder 锁持有者标识
- * @param createSnapshot 是否在上传前创建本地快照
  */
 export async function smartPush(
   config: SyncConfig,
   lockHolder: string,
-  createSnapshot = false,
 ): Promise<SyncResult> {
+  const startTime = Date.now();
+  console.log(`[SyncService] Starting push by "${lockHolder}"`);
+
   // 检查网络
   if (!navigator.onLine) {
+    console.warn("[SyncService] Push aborted: offline");
     return { success: false, action: "error", message: "网络断开" };
   }
 
   // 获取锁
   const lockAcquired = await acquireSyncLock(lockHolder);
   if (!lockAcquired) {
+    console.warn("[SyncService] Push aborted: lock not acquired");
     return { success: false, action: "error", message: "同步正在进行中" };
   }
 
@@ -103,22 +163,31 @@ export async function smartPush(
     const client = getClient(config);
 
     // 1. 获取本地书签
+    console.log("[SyncService] Getting local bookmarks...");
     const localTree = await BookmarkService.getTree();
     const localCount = BookmarkService.countBookmarks(localTree);
+    console.log(`[SyncService] Local: ${localCount} bookmarks`);
 
     // 安全检查：书签为空时不同步
     if (localCount === 0) {
+      console.error("[SyncService] Push aborted: local bookmarks empty");
       return { success: false, action: "error", message: "本地书签为空" };
     }
 
     // 2. 获取云端数据并比对
+    console.log("[SyncService] Checking cloud state...");
     try {
       const cloudJson = await client.getFile(FILE);
       if (cloudJson) {
         const cloudData = JSON.parse(cloudJson) as CloudBackup;
+        const cloudCount = cloudData.metadata?.totalCount || 0;
+        const cloudTime = cloudData.metadata?.timestamp || 0;
+
+        console.log(
+          `[SyncService] Cloud: ${cloudCount} bookmarks (${new Date(cloudTime).toISOString()})`,
+        );
 
         // 检查云端是否有未拉取的新版本
-        const cloudTime = cloudData.metadata?.timestamp || 0;
         const result = await browser.storage.local.get([
           "lastSyncTime",
           "lastSyncUrl",
@@ -129,6 +198,9 @@ export async function smartPush(
             : 0;
 
         if (cloudTime > lastSyncTime) {
+          console.warn(
+            `[SyncService] Cloud is newer (cloud: ${new Date(cloudTime).toISOString()}, last: ${new Date(lastSyncTime).toISOString()})`,
+          );
           return {
             success: false,
             action: "error",
@@ -137,55 +209,78 @@ export async function smartPush(
         }
 
         // 比对内容
-        const isIdentical = BookmarkService.compareWithCloud(
+        console.log("[SyncService] Comparing content...");
+        const isIdentical = await BookmarkService.compareWithCloud(
           localTree,
           cloudData,
         );
+
         if (isIdentical) {
-          // 内容相同，只更新同步时间
-          await browser.storage.local.set({
-            lastSyncTime: Date.now(),
-            lastSyncUrl: config.url,
-            lastSyncType: "skip_identical",
-          });
-          return {
-            success: true,
-            action: "skipped",
-            message: "书签已同步，无需更新",
-          };
+          // 检查是否为手动同步且浏览器一致
+          const localBrowserInfo = getBrowserInfo();
+          const cloudBrowser = cloudData.metadata?.browser || "";
+          const isBrowserMatch = isSameBrowser(localBrowserInfo.name, cloudBrowser);
+          const isManualSync = lockHolder === "manual";
+
+          // 手动同步 + 浏览器一致 → 即使内容相同也更新云端时间戳
+          if (isManualSync && isBrowserMatch) {
+            console.log("[SyncService] Content identical but manual sync from same browser, updating timestamp");
+            // 继续执行上传，更新云端时间戳
+          } else {
+            console.log("[SyncService] Content identical, skipping upload");
+            // 内容相同，只更新同步时间
+            await browser.storage.local.set({
+              lastSyncTime: Date.now(),
+              lastSyncUrl: config.url,
+              lastSyncType: "skip_identical",
+            });
+            return {
+              success: true,
+              action: "skipped",
+              message: "书签已同步，无需更新",
+            };
+          }
+        } else {
+          console.log("[SyncService] Content differs, will upload");
         }
+      } else {
+        console.log("[SyncService] No cloud backup found, first upload");
       }
-    } catch {
+    } catch (error) {
+      console.warn("[SyncService] Failed to check cloud state:", error);
       // 云端文件不存在或无法获取，继续上传
     }
 
-    // 3. 创建快照（可选）
-    if (createSnapshot) {
-      await BackupService.createSnapshot(localTree, localCount, "上传前备份");
-    }
-
-    // 4. 执行上传
+    // 3. 执行上传
+    console.log("[SyncService] Uploading to cloud...");
     const backup = await BookmarkService.createCloudBackup();
 
+    // 确保目录存在
     if (!(await client.exists(DIR))) {
+      console.log(`[SyncService] Creating directory: ${DIR}`);
       await client.createDirectory(DIR);
     }
 
     await client.putFile(FILE, JSON.stringify(backup));
 
-    // 5. 更新同步时间
+    // 4. 更新同步时间
     await browser.storage.local.set({
       lastSyncTime: Date.now(),
       lastSyncUrl: config.url,
       lastSyncType: "upload",
     });
 
+    const elapsed = Date.now() - startTime;
+    console.log(`[SyncService] Push completed in ${elapsed}ms`);
     return { success: true, action: "uploaded", message: "上传成功" };
   } catch (error) {
+    const elapsed = Date.now() - startTime;
+    const errorMessage = (error as Error).message || "上传失败";
+    console.error(`[SyncService] Push failed after ${elapsed}ms:`, error);
     return {
       success: false,
       action: "error",
-      message: (error as Error).message || "上传失败",
+      message: errorMessage,
     };
   } finally {
     await releaseSyncLock(lockHolder);
@@ -203,14 +298,19 @@ export async function smartPull(
   lockHolder: string,
   mode: "overwrite" | "merge" = "overwrite",
 ): Promise<SyncResult> {
+  const startTime = Date.now();
+  console.log(`[SyncService] Starting pull by "${lockHolder}" (mode: ${mode})`);
+
   // 检查网络
   if (!navigator.onLine) {
+    console.warn("[SyncService] Pull aborted: offline");
     return { success: false, action: "error", message: "网络断开" };
   }
 
   // 获取锁
   const lockAcquired = await acquireSyncLock(lockHolder);
   if (!lockAcquired) {
+    console.warn("[SyncService] Pull aborted: lock not acquired");
     return { success: false, action: "error", message: "同步正在进行中" };
   }
 
@@ -218,38 +318,48 @@ export async function smartPull(
     const client = getClient(config);
 
     // 1. 下载云端数据
+    console.log("[SyncService] Downloading from cloud...");
     const json = await client.getFile(FILE);
     if (!json) {
+      console.error("[SyncService] Pull aborted: no cloud data");
       return { success: false, action: "error", message: "云端无数据" };
     }
 
     const cloudData = JSON.parse(json) as CloudBackup;
+    const cloudCount = cloudData.metadata?.totalCount || 0;
+    const cloudTime = cloudData.metadata?.timestamp || 0;
+    const cloudBrowser = cloudData.metadata?.browser || "unknown";
 
-    // 2. 创建恢复前快照
-    const currentTree = await BookmarkService.getTree();
-    const currentCount = await BookmarkService.getLocalCount();
-    await BackupService.createSnapshot(currentTree, currentCount, "恢复前备份");
+    console.log(
+      `[SyncService] Cloud: ${cloudCount} bookmarks from ${cloudBrowser} (${new Date(cloudTime).toISOString()})`,
+    );
 
-    // 3. 恢复
+    // 2. 恢复书签
+    console.log(`[SyncService] Restoring bookmarks (${mode} mode)...`);
     if (mode === "overwrite") {
       await BookmarkService.restoreFromBackup(cloudData);
     } else {
       await BookmarkService.mergeFromBackup(cloudData);
     }
 
-    // 4. 更新同步时间
+    // 3. 更新同步时间
     await browser.storage.local.set({
       lastSyncTime: Date.now(),
       lastSyncUrl: config.url,
       lastSyncType: "download",
     });
 
+    const elapsed = Date.now() - startTime;
+    console.log(`[SyncService] Pull completed in ${elapsed}ms`);
     return { success: true, action: "downloaded", message: "同步完成" };
   } catch (error) {
+    const elapsed = Date.now() - startTime;
+    const errorMessage = (error as Error).message || "恢复失败";
+    console.error(`[SyncService] Pull failed after ${elapsed}ms:`, error);
     return {
       success: false,
       action: "error",
-      message: (error as Error).message || "恢复失败",
+      message: errorMessage,
     };
   } finally {
     await releaseSyncLock(lockHolder);
@@ -272,6 +382,7 @@ export interface CloudInfo {
  */
 export async function getCloudInfo(config: SyncConfig): Promise<CloudInfo> {
   if (!navigator.onLine) {
+    console.log("[SyncService] getCloudInfo: offline");
     return { exists: false };
   }
 
@@ -279,18 +390,25 @@ export async function getCloudInfo(config: SyncConfig): Promise<CloudInfo> {
     const client = getClient(config);
     const json = await client.getFile(FILE);
     if (!json) {
+      console.log("[SyncService] No cloud backup exists");
       return { exists: false };
     }
 
     const data = JSON.parse(json) as CloudBackup;
-    return {
+    const info: CloudInfo = {
       exists: true,
       timestamp: data.metadata?.timestamp,
       totalCount: data.metadata?.totalCount,
       browser: data.metadata?.browser,
       browserVersion: data.metadata?.browserVersion,
     };
-  } catch {
+
+    console.log(
+      `[SyncService] Cloud info: ${info.totalCount} bookmarks from ${info.browser || "unknown"}`,
+    );
+    return info;
+  } catch (error) {
+    console.error("[SyncService] Failed to get cloud info:", error);
     return { exists: false };
   }
 }
@@ -312,14 +430,19 @@ export async function smartSync(
   config: SyncConfig,
   lockHolder: string,
 ): Promise<SmartSyncResult> {
+  const startTime = Date.now();
+  console.log(`[SyncService] Starting smart sync by "${lockHolder}"`);
+
   // 检查网络
   if (!navigator.onLine) {
+    console.warn("[SyncService] Smart sync aborted: offline");
     return { success: false, action: "error", message: "网络断开" };
   }
 
   // 获取锁
   const lockAcquired = await acquireSyncLock(lockHolder);
   if (!lockAcquired) {
+    console.warn("[SyncService] Smart sync aborted: lock not acquired");
     return { success: false, action: "error", message: "同步正在进行中" };
   }
 
@@ -327,9 +450,13 @@ export async function smartSync(
     const client = getClient(config);
 
     // 1. 获取本地书签
+    console.log("[SyncService] Getting local bookmarks...");
     const localTree = await BookmarkService.getTree();
+    const localCount = BookmarkService.countBookmarks(localTree);
+    console.log(`[SyncService] Local: ${localCount} bookmarks`);
 
     // 2. 获取云端数据
+    console.log("[SyncService] Getting cloud data...");
     let cloudData: CloudBackup | null = null;
     let cloudInfo: CloudInfo = { exists: false };
 
@@ -344,21 +471,28 @@ export async function smartSync(
           browser: cloudData.metadata?.browser,
           browserVersion: cloudData.metadata?.browserVersion,
         };
+        console.log(
+          `[SyncService] Cloud: ${cloudInfo.totalCount} bookmarks from ${cloudInfo.browser || "unknown"}`,
+        );
       }
-    } catch {
-      // 云端无数据
+    } catch (error) {
+      console.warn("[SyncService] No cloud data found:", error);
     }
 
     // Case A: 云端无数据 → 直接上传
     if (!cloudData) {
+      console.log("[SyncService] No cloud backup, uploading...");
       // 释放锁后重新调用 smartPush（它会获取自己的锁）
       await releaseSyncLock(lockHolder);
-      return await smartPush(config, lockHolder, false);
+      return await smartPush(config, lockHolder);
     }
 
     // 3. 比对内容
-    const isIdentical = BookmarkService.compareWithCloud(localTree, cloudData);
+    console.log("[SyncService] Comparing local and cloud...");
+    const isIdentical = await BookmarkService.compareWithCloud(localTree, cloudData);
+
     if (isIdentical) {
+      console.log("[SyncService] Content identical, no sync needed");
       await browser.storage.local.set({
         lastSyncTime: Date.now(),
         lastSyncUrl: config.url,
@@ -378,9 +512,13 @@ export async function smartSync(
       "lastSyncUrl",
     ]);
     const lastSyncUrl = storage.lastSyncUrl as string | undefined;
-    let lastSyncTime =
+    const lastSyncTime =
       lastSyncUrl === config.url ? (storage.lastSyncTime as number) || 0 : 0;
     const cloudTime = cloudData.metadata?.timestamp || 0;
+
+    console.log(
+      `[SyncService] Sync times - Last: ${new Date(lastSyncTime).toISOString()}, Cloud: ${new Date(cloudTime).toISOString()}`,
+    );
 
     // 首次同步或环境变更，且云端有数据 → 需要用户选择
     if (
@@ -388,6 +526,7 @@ export async function smartSync(
       cloudInfo.totalCount &&
       cloudInfo.totalCount > 0
     ) {
+      console.warn("[SyncService] First sync detected, need user choice");
       return {
         success: false,
         action: "error",
@@ -398,23 +537,31 @@ export async function smartSync(
     }
 
     // 5. 智能判断
+    await releaseSyncLock(lockHolder);
+
     if (cloudTime > lastSyncTime) {
       // 云端比本地新 → 拉取
-      // 释放锁后重新调用
-      await releaseSyncLock(lockHolder);
+      console.log("[SyncService] Cloud is newer, pulling...");
       const result = await smartPull(config, lockHolder, "overwrite");
+      const elapsed = Date.now() - startTime;
+      console.log(`[SyncService] Smart sync completed (pull) in ${elapsed}ms`);
       return { ...result, cloudInfo };
     } else {
       // 本地可能更新 → 上传
-      await releaseSyncLock(lockHolder);
-      const result = await smartPush(config, lockHolder, false);
+      console.log("[SyncService] Local might be newer, pushing...");
+      const result = await smartPush(config, lockHolder);
+      const elapsed = Date.now() - startTime;
+      console.log(`[SyncService] Smart sync completed (push) in ${elapsed}ms`);
       return { ...result, cloudInfo };
     }
   } catch (error) {
+    const elapsed = Date.now() - startTime;
+    const errorMessage = (error as Error).message || "同步失败";
+    console.error(`[SyncService] Smart sync failed after ${elapsed}ms:`, error);
     return {
       success: false,
       action: "error",
-      message: (error as Error).message || "同步失败",
+      message: errorMessage,
     };
   } finally {
     // 确保锁被释放（如果还持有的话）

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -10,7 +10,8 @@ export interface BookmarkMetadata {
 }
 
 export interface BookmarkNode {
-  id: string;
+  id?: string; // 浏览器原生 ID（仅本地/系统文件夹使用，云端数据可能没有）
+  hash?: string; // 内容哈希（用于跨浏览器同步）= sha256(url + "|" + title)
   parentId?: string;
   index?: number;
   url?: string;


### PR DESCRIPTION
## 主要变化

### 1. 核心架构重构
- 将同步标识从 UUID 改为内容哈希（SHA-256）
- Hash 计算：sha256(url + "|" + title)
- 移除所有 browser.storage.local 依赖
- 简化代码约 200 行（~20% 代码减少）

### 2. 新增功能
- generateHash(): 基于 URL 和 title 生成哈希
- extractSignaturesWithHash(): 使用哈希进行精确比对
- findNodeByHash(): 通过哈希查找节点

### 3. 修复的问题
- 修复每次同步都提示"上传成功"的问题
  - 原因：比较本地树（完整字段）和云端树（精简字段）不一致
  - 解决：compareWithCloud 现在先将本地树精简后再比较
- 修复跨浏览器系统文件夹匹配失败
  - 原因：上传时丢失 folderType 字段
  - 解决：为系统文件夹同时保留 id 和 folderType
- 静默忽略 Firefox 独有的系统文件夹（书签菜单、移动设备书签）

### 4. 功能改进
- 支持重复 URL 书签（相同 URL 不同 title）
- 修改 title/URL 时自动通过 hash 变化检测
- 移动书签时通过 hash 不变 + 位置变化识别
- 更准确的增删改查支持

### 5. 性能优化
- 移除 UUID 映射的存储和查询开销
- Hash 动态计算，无需持久化
- 减少 storage.local 读写操作

### 6. 技术细节
- BookmarkNode.uuid → BookmarkNode.hash
- GlobalIndex.uuidToNode → GlobalIndex.hashToNode
- buildGlobalIndex 改为 async（需要计算 hash）
- compareWithCloud 改为 async（需要生成哈希树）
- 云端备份版本号更新为 2.0.0-hash

## 影响范围
- ✅ 增加书签：hash 唯一标识
- ✅ 删除书签：hash 不存在则删除
- ✅ 修改 title/URL：hash 变化自动重建
- ✅ 移动书签：hash 相同 + index 变化
- ✅ 重复 URL：不同 title 产生不同 hash
- ✅ 跨浏览器：通过 hash 直接匹配，无需映射

## 测试建议
1. 测试基本同步（增删改移）
2. 测试重复 URL 书签
3. 测试跨浏览器同步（Chrome ↔ Firefox ↔ Edge）
4. 测试连续点击同步（应该只有首次上传）
5. 测试系统文件夹匹配