### PR TITLE
fix: prevent duplicate bookmarks after cloud sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookmark-syncer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A privacy-first bookmark sync extension based on WebDAV. Supports Chrome, Firefox, and Edge.",
   "private": true,
   "scripts": {

--- a/packages/app/src/application/constants.ts
+++ b/packages/app/src/application/constants.ts
@@ -11,9 +11,6 @@ export const ALARM_NAME = "scheduledSync";
 /** 防抖闹钟名称 */
 export const DEBOUNCE_ALARM = "autoSyncDebounce";
 
-/** 重置恢复状态闹钟名称 */
-export const RESET_RESTORING_ALARM = "resetRestoring";
-
 /** storage.session 中的恢复状态键 */
 export const RESTORING_KEY = "isRestoring";
 

--- a/packages/app/src/application/scheduler.ts
+++ b/packages/app/src/application/scheduler.ts
@@ -4,8 +4,8 @@
  */
 import browser from "webextension-polyfill";
 import { handleDebounceAlarm } from "./bookmark-monitor";
-import { ALARM_NAME, DEBOUNCE_ALARM, RESET_RESTORING_ALARM } from "./constants";
-import { getWebDAVConfig, setIsRestoring } from "./state-manager";
+import { ALARM_NAME, DEBOUNCE_ALARM } from "./constants";
+import { getWebDAVConfig } from "./state-manager";
 import { executeAutoPull } from "./sync-executor";
 
 /**
@@ -166,12 +166,6 @@ export function registerAlarmListener(): void {
         case ALARM_NAME:
           // 定时同步
           await handleScheduledAlarm(alarm);
-          break;
-
-        case RESET_RESTORING_ALARM:
-          // 重置恢复状态
-          console.log("[Scheduler] Resetting restoring state");
-          await setIsRestoring(false);
           break;
 
         default:

--- a/packages/app/src/application/state-manager.ts
+++ b/packages/app/src/application/state-manager.ts
@@ -5,7 +5,17 @@
 import browser from "webextension-polyfill";
 import type { LastBackupFileInfo } from "../core/storage/types";
 import { STORAGE_CONSTANTS } from "../core/storage/types";
-import { RESTORING_KEY, RESTORING_TIMEOUT_MS } from "./constants";
+import { RESET_RESTORING_DELAY_MS, RESTORING_KEY, RESTORING_TIMEOUT_MS } from "./constants";
+
+type RestoringState = {
+  value: boolean;
+  timestamp: number;
+  until?: number;
+};
+
+function getRestoringStorageArea(): typeof browser.storage.local | typeof browser.storage.session {
+  return browser.storage.session ?? browser.storage.local;
+}
 
 /**
  * 检查是否正在执行恢复操作
@@ -13,20 +23,24 @@ import { RESTORING_KEY, RESTORING_TIMEOUT_MS } from "./constants";
  */
 export async function getIsRestoring(): Promise<boolean> {
   try {
-    // Firefox 不支持 storage.session，此时返回 false
-    if (!browser.storage.session) {
-      return false;
-    }
-
-    const result = await browser.storage.session.get(RESTORING_KEY);
-    const state = result[RESTORING_KEY] as
-      | { value: boolean; timestamp: number }
-      | undefined;
+    const storageArea = getRestoringStorageArea();
+    const result = await storageArea.get(RESTORING_KEY);
+    const state = result[RESTORING_KEY] as RestoringState | undefined;
 
     if (!state) return false;
 
-    // 检查超时（防止异常情况下状态一直锁定）
     const now = Date.now();
+
+    if (typeof state.until === "number") {
+      if (now >= state.until) {
+        await setIsRestoring(false);
+        return false;
+      }
+
+      return state.value;
+    }
+
+    // 检查超时（防止异常情况下状态一直锁定）
     if (now - state.timestamp > RESTORING_TIMEOUT_MS) {
       console.warn(
         `[StateManager] Restoring state timeout (${now - state.timestamp}ms), auto clearing`,
@@ -47,13 +61,10 @@ export async function getIsRestoring(): Promise<boolean> {
  */
 export async function setIsRestoring(value: boolean): Promise<void> {
   try {
-    if (!browser.storage.session) {
-      console.warn("[StateManager] storage.session not supported");
-      return;
-    }
+    const storageArea = getRestoringStorageArea();
 
     if (value) {
-      await browser.storage.session.set({
+      await storageArea.set({
         [RESTORING_KEY]: {
           value: true,
           timestamp: Date.now(),
@@ -61,11 +72,32 @@ export async function setIsRestoring(value: boolean): Promise<void> {
       });
       console.log("[StateManager] Restoring state activated");
     } else {
-      await browser.storage.session.remove(RESTORING_KEY);
+      await storageArea.remove(RESTORING_KEY);
       console.log("[StateManager] Restoring state cleared");
     }
   } catch (error) {
     console.error("[StateManager] Failed to set restoring state:", error);
+  }
+}
+
+/**
+ * 在恢复结束后保留一个短暂阻塞窗口，避免收尾事件立即触发同步
+ */
+export async function holdRestoringUntil(delayMs = RESET_RESTORING_DELAY_MS): Promise<void> {
+  try {
+    const storageArea = getRestoringStorageArea();
+    const now = Date.now();
+    await storageArea.set({
+      [RESTORING_KEY]: {
+        value: true,
+        timestamp: now,
+        until: now + delayMs,
+      } satisfies RestoringState,
+    });
+    console.log(`[StateManager] Restoring hold scheduled for ${delayMs}ms`);
+  } catch (error) {
+    console.error("[StateManager] Failed to hold restoring state:", error);
+    await setIsRestoring(false);
   }
 }
 

--- a/packages/app/src/application/sync-executor.ts
+++ b/packages/app/src/application/sync-executor.ts
@@ -6,8 +6,6 @@ import browser from "webextension-polyfill";
 import { getCloudInfo, smartPull, smartPush, type SyncState } from "../core/sync";
 import {
     LOCK_HOLDER_AUTO,
-    RESET_RESTORING_ALARM,
-    RESET_RESTORING_DELAY_MS,
     SYNC_STATE_KEY,
 } from "./constants";
 import { getIsRestoring, getWebDAVConfig, setIsRestoring } from "./state-manager";
@@ -56,27 +54,15 @@ export async function executeUpload(): Promise<void> {
       console.log(
         `[SyncExecutor] Cloud has updates, pulling first (cloud: ${new Date(cloudTime).toISOString()}, local: ${new Date(lastSyncTime).toISOString()})`,
       );
-      
-      // 标记正在恢复，避免拉取过程中触发新的上传
-      await setIsRestoring(true);
-      
-      try {
-        // 使用 merge 模式：保留本地新增的书签
-        const pullResult = await smartPull(config, LOCK_HOLDER_AUTO, "merge");
-        
-        if (!pullResult.success) {
-          console.warn(`[SyncExecutor] Pull before upload failed: ${pullResult.message}`);
-          // 不在此处重置 restoring，由 finally 中的 Alarm 统一处理
-          return;
-        }
-        
-        console.log("[SyncExecutor] Pull completed, now uploading merged result...");
-      } finally {
-        // 使用 Alarm 延迟重置恢复标志
-        await browser.alarms.create(RESET_RESTORING_ALARM, {
-          when: Date.now() + RESET_RESTORING_DELAY_MS,
-        });
+      // 使用 merge 模式：保留本地新增的书签
+      const pullResult = await smartPull(config, LOCK_HOLDER_AUTO, "merge");
+
+      if (!pullResult.success) {
+        console.warn(`[SyncExecutor] Pull before upload failed: ${pullResult.message}`);
+        return;
       }
+
+      console.log("[SyncExecutor] Pull completed, now uploading merged result...");
     }
 
     console.log("[SyncExecutor] Starting upload...");
@@ -151,23 +137,12 @@ export async function executeAutoPull(): Promise<void> {
       `[SyncExecutor] Cloud update detected (${cloudInfo.totalCount} bookmarks from ${cloudInfo.browser || "unknown"})`,
     );
 
-    // 标记正在恢复，阻止书签变化事件触发上传
-    await setIsRestoring(true);
+    const pullResult = await smartPull(config, LOCK_HOLDER_AUTO, "overwrite");
 
-    try {
-      const pullResult = await smartPull(config, LOCK_HOLDER_AUTO, "overwrite");
-
-      if (pullResult.success) {
-        console.log(`[SyncExecutor] Pull ${pullResult.action}: ${pullResult.message}`);
-      } else {
-        console.warn(`[SyncExecutor] Pull failed: ${pullResult.message}`);
-      }
-    } finally {
-      // 使用 Alarm 延迟重置恢复标志（避免 setTimeout 在 SW 休眠后丢失）
-      // 延迟时间足够长，确保书签恢复操作完全完成
-      await browser.alarms.create(RESET_RESTORING_ALARM, {
-        when: Date.now() + RESET_RESTORING_DELAY_MS,
-      });
+    if (pullResult.success) {
+      console.log(`[SyncExecutor] Pull ${pullResult.action}: ${pullResult.message}`);
+    } else {
+      console.warn(`[SyncExecutor] Pull failed: ${pullResult.message}`);
     }
   } catch (error) {
     console.error("[SyncExecutor] Pull error:", error);

--- a/packages/app/src/components/SyncView.tsx
+++ b/packages/app/src/components/SyncView.tsx
@@ -3,7 +3,7 @@ import { useOnlineStatus } from '../hooks/useOnlineStatus'
 
 import { motion } from 'framer-motion'
 import { AlertTriangle, Cloud, Download, FilePlus, History, RefreshCw, RotateCcw, ShieldCheck, Trash2, WifiOff } from 'lucide-react'
-import { clearLastBackupFileInfo } from '../application/state-manager'
+import { clearLastBackupFileInfo, holdRestoringUntil, setIsRestoring } from '../application/state-manager'
 import { snapshotManager, type Snapshot } from '../core/backup'
 import { bookmarkRepository, countBookmarks } from '../core/bookmark'
 import { getCloudBackupList, getCloudInfo, restoreFromCloudBackup, smartPull, smartPush, smartSync, type CloudBackupFile } from '../core/sync'
@@ -207,6 +207,8 @@ export function SyncView() {
     setDrawerOpen(false)
     
     try {
+            await setIsRestoring(true)
+
       // 先备份当前状态（本地快照恢复前）
       const currentTree = await bookmarkRepository.getTree()
       const currentCount = countBookmarks(currentTree)
@@ -224,6 +226,8 @@ export function SyncView() {
       setMsg('恢复失败')
       toast.error('恢复失败', { description: (e as Error).message })
     } finally {
+            await holdRestoringUntil()
+
       setPendingRestoreSnapshot(null)
     }
   }

--- a/packages/app/src/core/bookmark/merger.ts
+++ b/packages/app/src/core/bookmark/merger.ts
@@ -173,6 +173,27 @@ function findNodeByHash(
   return undefined;
 }
 
+function normalizeTitle(title: string | undefined): string {
+  return title?.trim() || "";
+}
+
+function getBookmarkIdentityKeys(
+  node: BookmarkNode,
+  normalizedUrl = normalizeUrl(node.url),
+): string[] {
+  const keys = [`bookmark:${normalizedUrl}|${normalizeTitle(node.title)}`];
+
+  if (node.hash) {
+    keys.unshift(`hash:${node.hash}`);
+  }
+
+  return keys;
+}
+
+function getFolderIdentityKey(node: BookmarkNode): string {
+  return `folder:${normalizeTitle(node.title)}`;
+}
+
 /**
  * 递归创建子节点
  */
@@ -233,14 +254,18 @@ export async function smartSync(
   );
 
   // 获取当前本地文件夹的子节点
-  const localChildren = (await BrowserBookmarksAPI.getChildren(
+  const localChildren = [...((await BrowserBookmarksAPI.getChildren(
     localParentId,
-  )) as BookmarkNode[];
+  )) as BookmarkNode[])];
 
   console.log(`[Merger] Local folder has ${localChildren.length} children`);
 
   // 已处理的本地 ID（防止重复处理）
   const processedLocalIds = new Set<string>();
+  // 同一文件夹内已处理的云端书签身份（防止不可区分的重复项继续创建）
+  const processedBookmarkKeys = new Set<string>();
+  // 同一文件夹内已确定目标的文件夹（允许后续同名文件夹复用同一目标）
+  const folderTargets = new Map<string, BookmarkNode>();
   // 已使用的 URL（用于检测重复）
   const usedUrls = new Set<string>();
 
@@ -261,6 +286,15 @@ export async function smartSync(
     if (cloudNode.url) {
       // === 处理书签 ===
       const normalizedUrl = normalizeUrl(cloudNode.url);
+      const bookmarkIdentityKeys = getBookmarkIdentityKeys(cloudNode, normalizedUrl);
+
+      if (bookmarkIdentityKeys.some((key) => processedBookmarkKeys.has(key))) {
+        console.log(
+          `[Merger] Skipping duplicate cloud bookmark "${cloudNode.title}" in "${localParentPath}"`,
+        );
+        continue;
+      }
+
       let matchedLocal: BookmarkNode | undefined;
 
       // 1. 优先通过 Hash 匹配（最可靠）
@@ -305,6 +339,9 @@ export async function smartSync(
 
       if (matchedLocal && matchedLocal.id) {
         processedLocalIds.add(matchedLocal.id);
+        for (const key of bookmarkIdentityKeys) {
+          processedBookmarkKeys.add(key);
+        }
         usedUrls.add(normalizedUrl);
 
         // 检查是否需要更新
@@ -371,6 +408,10 @@ export async function smartSync(
           });
           if (newBookmark.id) {
             processedLocalIds.add(newBookmark.id); // 记录新创建的 ID，防止 Phase 3 误删
+            localChildren.push(newBookmark as BookmarkNode);
+            for (const key of bookmarkIdentityKeys) {
+              processedBookmarkKeys.add(key);
+            }
             stats.bookmarksCreated++;
           }
         } catch (error) {
@@ -385,6 +426,19 @@ export async function smartSync(
       const cloudFolderPath = localParentPath
         ? `${localParentPath}/${cloudNode.title}`
         : cloudNode.title;
+      const folderIdentityKey = getFolderIdentityKey(cloudNode);
+      const existingTarget = folderTargets.get(folderIdentityKey);
+
+      if (existingTarget?.id) {
+        await smartSync(
+          existingTarget.id,
+          cloudNode.children,
+          localIndex,
+          cloudFolderPath,
+        );
+        continue;
+      }
+
       let matchedFolder: BookmarkNode | undefined;
 
       // 1. 先在当前文件夹找同名文件夹（简单匹配）
@@ -412,6 +466,7 @@ export async function smartSync(
 
       if (matchedFolder && matchedFolder.id) {
         processedLocalIds.add(matchedFolder.id);
+        folderTargets.set(folderIdentityKey, matchedFolder);
 
         // 更新标题（如果改名了）
         if ((matchedFolder.title?.trim() || "") !== (cloudNode.title?.trim() || "")) {
@@ -471,10 +526,18 @@ export async function smartSync(
           });
           if (created.id) {
             processedLocalIds.add(created.id); // 记录新创建的 ID，防止 Phase 3 误删
+            const createdFolder = { ...(created as BookmarkNode), children: [] };
+            localChildren.push(createdFolder);
+            folderTargets.set(folderIdentityKey, createdFolder);
             stats.foldersCreated++;
 
-            // 递归创建子节点
-            await createChildren(created.id, cloudNode.children);
+            // 继续走 smartSync，让新建文件夹的子节点也受同轮去重保护
+            await smartSync(
+              created.id,
+              cloudNode.children,
+              localIndex,
+              cloudFolderPath,
+            );
           }
         } catch (error) {
           console.warn(
@@ -547,7 +610,7 @@ export async function smartSync(
  * 用于保守的合并策略
  */
 export async function mergeNodes(parentId: string, nodes: BookmarkNode[]): Promise<void> {
-  const localChildren = await BrowserBookmarksAPI.getChildren(parentId);
+  const localChildren = [...((await BrowserBookmarksAPI.getChildren(parentId)) as BookmarkNode[])];
   let addedCount = 0;
 
   for (const node of nodes) {
@@ -556,12 +619,13 @@ export async function mergeNodes(parentId: string, nodes: BookmarkNode[]): Promi
       const exists = localChildren.some((local) => normalizeUrl(local.url) === normalizedNodeUrl);
       if (!exists) {
         try {
-          await BrowserBookmarksAPI.create({
+          const createdBookmark = await BrowserBookmarksAPI.create({
             parentId,
             title: node.title,
             url: node.url,
             index: node.index,
           });
+          localChildren.push(createdBookmark as BookmarkNode);
           addedCount++;
         } catch (error) {
           console.warn(
@@ -575,7 +639,7 @@ export async function mergeNodes(parentId: string, nodes: BookmarkNode[]): Promi
         (local) => !local.url && local.title === node.title,
       );
 
-      if (existingFolder) {
+      if (existingFolder?.id) {
         if (node.children && node.children.length > 0) {
           await mergeNodes(existingFolder.id, node.children);
         }
@@ -586,10 +650,11 @@ export async function mergeNodes(parentId: string, nodes: BookmarkNode[]): Promi
             title: node.title,
             index: node.index,
           });
+          localChildren.push({ ...(newFolder as BookmarkNode), children: [] });
           addedCount++;
 
           if (node.children && node.children.length > 0) {
-            await createChildren(newFolder.id, node.children);
+            await mergeNodes(newFolder.id, node.children);
           }
         } catch (error) {
           console.warn(

--- a/packages/app/src/core/sync/cloud-operations.ts
+++ b/packages/app/src/core/sync/cloud-operations.ts
@@ -4,6 +4,7 @@
  */
 import { getWebDAVClient } from "../../infrastructure/http/webdav-client";
 import { CloudBackup } from "../../types";
+import { holdRestoringUntil, setIsRestoring } from "../../application/state-manager";
 import { snapshotManager } from "../backup";
 import { bookmarkRepository, countBookmarks } from "../bookmark";
 import { fileManager, STORAGE_CONSTANTS } from "../storage";
@@ -136,6 +137,8 @@ export async function restoreFromCloudBackup(
   }
 
   try {
+    await setIsRestoring(true);
+
     const client = getWebDAVClient(config);
 
     // 路径问题已修复，理论上不再需要智能等待
@@ -209,6 +212,8 @@ export async function restoreFromCloudBackup(
       message: errorMessage,
     };
   } finally {
+    await holdRestoringUntil();
+
     await releaseSyncLock(lockHolder);
   }
 }

--- a/packages/app/src/core/sync/strategies/pull-strategy.ts
+++ b/packages/app/src/core/sync/strategies/pull-strategy.ts
@@ -4,6 +4,7 @@
  */
 import { getWebDAVClient } from "../../../infrastructure/http/webdav-client";
 import { CloudBackup } from "../../../types";
+import { holdRestoringUntil, setIsRestoring } from "../../../application/state-manager";
 import { snapshotManager } from "../../backup";
 import { bookmarkRepository, countBookmarks } from "../../bookmark";
 import type { WebDAVConfig } from "../../storage";
@@ -46,6 +47,8 @@ export async function smartPull(
   }
 
   try {
+    await setIsRestoring(true);
+
     const client = getWebDAVClient(config);
 
     // 0. 创建本地快照（下载前备份）
@@ -128,6 +131,8 @@ export async function smartPull(
       message: errorMessage,
     };
   } finally {
+    await holdRestoringUntil();
+
     if (!skipLock) {
       await releaseSyncLock(lockHolder);
     }


### PR DESCRIPTION
## Summary
- unify restoring lifecycle to block sync event feedback during restore
- remove obsolete restoring reset alarm flow
- add same-run dedupe protection in bookmark restore and merge logic
- bump version to 1.0.8

## Notes
- focuses on duplicate bookmarks appearing after cloud sync completes
- build blocking TypeScript issue in merger was also corrected during packaging validation